### PR TITLE
fix {Mikefile} webapp-clean instruction.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ webapp:
 
 .PHONY: webapp-clean
 webapp-clean:
-	rm -r dist
+	rm -r static/dist
 
 .PHONY: clean
 clean: webapp-clean


### PR DESCRIPTION
Previous Makefile has a problem about 'webapp-clean dir', appears like:

![图片](https://github.com/user-attachments/assets/67359496-c30b-4dc5-8f98-f7db68a5b462)
 
Supplementing prefix path solved this.

