### PR TITLE
fix unreasonable room user information status

### DIFF
--- a/webapp/components/layout.tsx
+++ b/webapp/components/layout.tsx
@@ -46,6 +46,19 @@ export default function Layout(props: { meetingId: string }) {
     setMeetingJoined(false)
   }
 
+  useEffect(() => {
+    const cleanup = () => {
+      delStream(props.meetingId, localStreamId)
+    }
+    // Need to set separate Browser Events Parameters for Firefox refresh and browser termination
+    window.addEventListener('beforeunload', cleanup) // Used to monitor the browser termination of Firefox event
+    window.addEventListener('unload', cleanup) // Used to monitor Firefox refresh event
+    return () => {
+      window.removeEventListener('beforeunload', cleanup)
+      window.removeEventListener('unload', cleanup)
+    }
+  }, [props.meetingId, localStreamId])
+
   //useEffect(() => {
   //  let shareScreenId = ""
   //  const setShareScreenId = (id: string) => shareScreenId = id

--- a/webapp/components/layout.tsx
+++ b/webapp/components/layout.tsx
@@ -50,9 +50,19 @@ export default function Layout(props: { meetingId: string }) {
     const cleanup = () => {
       delStream(props.meetingId, localStreamId)
     }
-    // Need to set separate Browser Events Parameters for Firefox refresh and browser termination
-    window.addEventListener('beforeunload', cleanup) // Used to monitor the browser termination of Firefox event
-    window.addEventListener('unload', cleanup) // Used to monitor Firefox refresh event
+    // NOTE:
+    // https://github.com/binbat/woom/pull/27
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event
+    // `unload` event is Deprecated, But Firefox need `unload`
+    //
+    // event                        | Chrome                    | Firefox                   | Safari
+    // ---------------------------- | ------------------------- | ------------------------- | -----
+    // `beforeunload`               | ok                        | console error, no request | console error, request ok
+    // `unload`                     | console error, no request | ok                        | console no request log, no request
+    // `beforeunload` + `keepalive` | ok                        | console error, no request | console error, request ok
+    // `unload` +  `keepalive`      | console error, request ok | ok                        | console no request log, request ok
+    window.addEventListener('beforeunload', cleanup)
+    window.addEventListener('unload', cleanup)
     return () => {
       window.removeEventListener('beforeunload', cleanup)
       window.removeEventListener('unload', cleanup)

--- a/webapp/lib/api.ts
+++ b/webapp/lib/api.ts
@@ -114,6 +114,7 @@ async function delStream(roomId: string, streamId: string): Promise<any> {
       'Authorization': `Bearer ${token}`,
     },
     method: 'DELETE',
+    keepalive: true,
   })
 }
 


### PR DESCRIPTION
When a user who originally joined a room **exits** due to some interruption (like a page refresh or browser closure), their status **still appears online** to other users in the room(_like the picture_), which doesn't make sense. Additionally, the Redis database will perpetually retain this "frozen" stream, resulting in a waste of resources.

![图片](https://github.com/user-attachments/assets/e998cc8f-76c5-4aae-af8b-bcd94d433a1f)

Add 'useEffect' listen interruption and release resources.