### PR TITLE
fix(webapp): change whxp userStatus default value

### DIFF
--- a/webapp/components/use/whxp.ts
+++ b/webapp/components/use/whxp.ts
@@ -19,8 +19,8 @@ class Context extends EventTarget {
   userStatus: Stream = {
     name: '',
     state: StreamState.New,
-    audio: true,
-    video: true,
+    audio: false,
+    video: false,
     screen: false,
   }
 

--- a/webapp/store/atom.ts
+++ b/webapp/store/atom.ts
@@ -37,7 +37,7 @@ enabledPresentationAtom.debugLabel = 'enabledPresentation'
 
 const deviceSpeakerAtom = atom<string>('')
 deviceSpeakerAtom.debugLabel = 'deviceSpeaker'
-const speakerStatusAtom = atom<boolean>(true)
+const speakerStatusAtom = atom<boolean>(false)
 speakerStatusAtom.debugLabel = 'speakerStatus'
 
 // Mobile device don't support share screen, For Mobile device default disabled


### PR DESCRIPTION
WHIPContext defaults to `deviceNone.deviceId` which means no audio/video

---

Fixes an issue that video stream cannot be disabled when no camera device is available.

When camera device is available, it would be enabled when entering [`Prepare`](https://github.com/binbat/woom/blob/4617eed258bd234f9de29d7096aaf9c9f14a6bd8/webapp/components/prepare.tsx#L16) page, since `DeviceBar` would iterate all media devices and enable them in [updateDeviceList](https://github.com/binbat/woom/blob/4617eed258bd234f9de29d7096aaf9c9f14a6bd8/webapp/components/device.tsx#L82) (which is definitely a bad design and needs refactor)

https://github.com/binbat/woom/blob/4617eed258bd234f9de29d7096aaf9c9f14a6bd8/webapp/components/device.tsx#L103-L116

