### PR TITLE
fix(webapp): enable video easily after stop sharing screen

### DIFF
--- a/webapp/components/use/whip.ts
+++ b/webapp/components/use/whip.ts
@@ -183,7 +183,7 @@ class WHIPContext extends Context {
       userStatus.video = current === deviceNone.deviceId ? false : true
       // NOTE: screen share
       userStatus.screen = current !== deviceScreen.deviceId ? false : true
-      this.currentDeviceVideo = (current === deviceNone.deviceId || current === deviceSegmenter.deviceId) ? this.currentDeviceVideo : current
+      this.currentDeviceVideo = (current === deviceNone.deviceId || current === deviceSegmenter.deviceId || current === deviceScreen.deviceId) ? this.currentDeviceVideo : current
       this.currentVideoConstraints = constraints
 
       this.sync()


### PR DESCRIPTION
After users stop sharing screen, it will default to disable video, and if users want to enable video and click 
![image](https://github.com/user-attachments/assets/3a120b7c-5a8f-4301-9350-f73dd4bfb71c)
 directly without changing devices, they will be guided to share their screen again, which can be quite confusing for users not familiar with that.