### PR TITLE
chore(webapp): display tip of disabled media

### DIFF
--- a/webapp/components/layout.tsx
+++ b/webapp/components/layout.tsx
@@ -99,7 +99,7 @@ export default function Layout(props: { meetingId: string }) {
       <div></div>
 
       {enabledPresentation
-        ? <Player stream={presentationStream.stream} muted={true} video={true} audio={false} width="auto" />
+        ? <Player stream={presentationStream.stream} muted={true} video={true} audio={false} width="auto" self={false}/>
         : null
       }
 

--- a/webapp/components/player/whep-player.tsx
+++ b/webapp/components/player/whep-player.tsx
@@ -53,7 +53,7 @@ export default function WhepPlayer(props: { streamId: string, userStatus: Stream
 
   return (
     <center className="relative flex flex-col">
-      <Player stream={stream} muted={false} width={props.width} audio={true} video={props.userStatus.video && !props.userStatus.screen} />
+      <Player stream={stream} muted={false} width={props.width} audio={props.userStatus.audio} video={props.userStatus.video && !props.userStatus.screen} self={false} />
       <Detail streamId={props.streamId} connStatus={connStatus} userStatus={props.userStatus} restart={restart} />
     </center>
   )

--- a/webapp/components/player/whip-player.tsx
+++ b/webapp/components/player/whip-player.tsx
@@ -30,7 +30,7 @@ export default function WhipPlayer(props: { streamId: string, width: string }) {
 
   return (
     <center className="relative flex flex-col">
-      <Player stream={stream} muted={true} width={props.width} audio={false} video={userStatus.video && !userStatus.screen} />
+      <Player stream={stream} muted={true} width={props.width} audio={userStatus.audio} video={userStatus.video && !userStatus.screen} self={true} />
       <Detail streamId={props.streamId} connStatus={userStatus.state} userStatus={userStatus} restart={restart} />
     </center>
   )

--- a/webapp/components/prepare.tsx
+++ b/webapp/components/prepare.tsx
@@ -18,7 +18,7 @@ export default function Prepare(_props: { meetingId: string }) {
   const localStreamId = getStorageStream()
   const [_, setMeetingJoined] = useAtom(meetingJoinedAtom)
 
-  const { id, stream, setUserName, setSyncUserStatus, restart } = useWhipClient(localStreamId)
+  const { id, stream, setUserName, setSyncUserStatus, restart, userStatus } = useWhipClient(localStreamId)
 
   const join = async () => {
     setLoading(true)
@@ -39,7 +39,7 @@ export default function Prepare(_props: { meetingId: string }) {
   return (
     <div className="flex flex-col justify-around">
       <center className="m-xs">
-        <Player stream={stream} muted={true} width="320px" audio={true} video={true} />
+        <Player stream={stream} muted={false} width="320px" audio={userStatus.audio} video={userStatus.video} self={true} />
       </center>
 
       <center className="mb-xs">


### PR DESCRIPTION
Close #49 .

Tip is displayed along with controls of the player when your mouse moves in, and it fades away when your mouse moves out.

<img width="320" height="240" alt="image" src="https://github.com/user-attachments/assets/f98ea87a-21af-4518-8b65-dab0e9b74061" />
